### PR TITLE
Add core models for concert and song matching with canonical truth

### DIFF
--- a/backend-go/migrations/000007_add_music_entities.down.sql
+++ b/backend-go/migrations/000007_add_music_entities.down.sql
@@ -1,0 +1,15 @@
+-- Remove video columns
+DROP INDEX IF EXISTS idx_videos_song_id;
+DROP INDEX IF EXISTS idx_videos_act_id;
+
+ALTER TABLE videos
+    DROP COLUMN IF EXISTS song_id,
+    DROP COLUMN IF EXISTS act_id;
+
+-- Drop tables in reverse dependency order
+DROP TABLE IF EXISTS acts;
+DROP TABLE IF EXISTS concerts;
+DROP TABLE IF EXISTS songs;
+DROP TABLE IF EXISTS artists;
+DROP TABLE IF EXISTS venues;
+

--- a/backend-go/migrations/000007_add_music_entities.up.sql
+++ b/backend-go/migrations/000007_add_music_entities.up.sql
@@ -1,0 +1,112 @@
+-- ============================================================================
+-- Music entity tables: artists, songs, venues, concerts, acts
+-- ============================================================================
+
+CREATE TABLE venues (
+    id              SERIAL PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    latitude        DOUBLE PRECISION,
+    longitude       DOUBLE PRECISION,
+    city            VARCHAR(255),
+    region          VARCHAR(255),
+    country_code    VARCHAR(2) NOT NULL,
+    address         TEXT,
+    google_place_id VARCHAR(255),
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at      TIMESTAMP
+);
+
+CREATE TABLE artists (
+    id                 SERIAL PRIMARY KEY,
+    name               VARCHAR(255) NOT NULL,
+    musicbrainz_id     VARCHAR(36) UNIQUE,
+    spotify_id         VARCHAR(255) UNIQUE,
+    rym_id             VARCHAR(255) UNIQUE,
+    image_url          TEXT,
+    is_verified        BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at         TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at         TIMESTAMP
+);
+
+CREATE TABLE songs (
+    id                        SERIAL PRIMARY KEY,
+    title                     VARCHAR(255) NOT NULL,
+    artist_id                 INTEGER NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    duration_seconds          INTEGER,
+    musicbrainz_recording_id  VARCHAR(36) UNIQUE,
+    isrc                      VARCHAR(12) UNIQUE,
+    is_verified               BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by_user_id        INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at                TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at                TIMESTAMP
+);
+
+CREATE TABLE concerts (
+    id           SERIAL PRIMARY KEY,
+    name         VARCHAR(255),
+    venue_id     INTEGER REFERENCES venues(id) ON DELETE SET NULL,
+    artist_id    INTEGER REFERENCES artists(id) ON DELETE SET NULL,  -- convenience denorm, NULL for multi-artist events
+    date         TIMESTAMP NOT NULL,
+    setlistfm_id VARCHAR(255) UNIQUE,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at   TIMESTAMP
+);
+
+CREATE TABLE acts (
+    id         SERIAL PRIMARY KEY,
+    concert_id INTEGER NOT NULL REFERENCES concerts(id) ON DELETE CASCADE,
+    artist_id  INTEGER NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    act_type   VARCHAR(50),
+
+    start_time TIMESTAMP,
+
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP,
+    
+    UNIQUE (concert_id, artist_id)
+);
+
+-- ============================================================================
+-- Update videos table
+-- ============================================================================
+
+ALTER TABLE videos
+    ADD COLUMN act_id  INTEGER REFERENCES acts(id) ON DELETE SET NULL,
+    ADD COLUMN song_id INTEGER REFERENCES songs(id) ON DELETE SET NULL;
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+-- Artists
+CREATE INDEX idx_artists_name ON artists(name);
+CREATE INDEX idx_artists_musicbrainz_id ON artists(musicbrainz_id) WHERE musicbrainz_id IS NOT NULL;
+CREATE INDEX idx_artists_spotify_id ON artists(spotify_id) WHERE spotify_id IS NOT NULL;
+CREATE INDEX idx_artists_rym_id ON artists(rym_id) WHERE rym_id IS NOT NULL;
+CREATE INDEX idx_artists_deleted_at ON artists(deleted_at) WHERE deleted_at IS NULL;
+
+-- Songs
+CREATE INDEX idx_songs_artist_id ON songs(artist_id);
+CREATE INDEX idx_songs_title ON songs(title);
+CREATE INDEX idx_songs_deleted_at ON songs(deleted_at) WHERE deleted_at IS NULL;
+
+-- Venues
+CREATE INDEX idx_venues_google_place_id ON venues(google_place_id) WHERE google_place_id IS NOT NULL;
+CREATE INDEX idx_venues_deleted_at ON venues(deleted_at) WHERE deleted_at IS NULL;
+
+-- Concerts
+CREATE INDEX idx_concerts_venue_id ON concerts(venue_id) WHERE venue_id IS NOT NULL;
+CREATE INDEX idx_concerts_artist_id ON concerts(artist_id) WHERE artist_id IS NOT NULL;
+CREATE INDEX idx_concerts_date ON concerts(date);
+CREATE INDEX idx_concerts_setlistfm_id ON concerts(setlistfm_id) WHERE setlistfm_id IS NOT NULL;
+CREATE INDEX idx_concerts_deleted_at ON concerts(deleted_at) WHERE deleted_at IS NULL;
+
+-- Acts
+CREATE INDEX idx_acts_concert_id ON acts(concert_id);
+CREATE INDEX idx_acts_artist_id ON acts(artist_id);
+CREATE INDEX idx_acts_act_type ON acts(act_type) WHERE act_type IS NOT NULL;
+
+-- Videos (new columns)
+CREATE INDEX idx_videos_act_id ON videos(act_id) WHERE act_id IS NOT NULL;
+CREATE INDEX idx_videos_song_id ON videos(song_id) WHERE song_id IS NOT NULL;

--- a/backend-go/models/act.go
+++ b/backend-go/models/act.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+// Act represents one artist's performance within a concert.
+//
+// Videos link to acts to identify the performer. The act_type field
+// distinguishes the role (main, opener, etc.)
+//
+// CONCERN: what if video attached to concert but not act?
+// QUERY LEVEL FALLBACK:
+// -- All videos for artist X
+// SELECT DISTINCT v.* FROM videos v
+// LEFT JOIN acts a ON v.act_id = a.id
+// WHERE
+//     -- Path 1: explicitly tagged
+//     a.artist_id = $1
+//     -- Path 2: untagged, but concert has exactly one act by this artist
+//     OR (v.act_id IS NULL AND v.event_type = 'concert' AND (
+//         SELECT COUNT(*) FROM acts WHERE concert_id = v.event_id
+//     ) = 1 AND EXISTS (
+//         SELECT 1 FROM acts WHERE concert_id = v.event_id AND artist_id = $1
+//     ))
+// ;
+type Act struct {
+	ID        int        `db:"id" json:"id"`
+	ConcertID int        `db:"concert_id" json:"concert_id"`
+	ArtistID  int        `db:"artist_id" json:"artist_id"`
+	ActType   *string    `db:"act_type" json:"act_type,omitempty"`
+
+	StartTime *time.Time `db:"start_time" json:"start_time"`
+
+	CreatedAt time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt *time.Time `db:"deleted_at" json:"-"`
+}
+
+// Act type constants
+const (
+	ActTypeMain   = "main"
+	ActTypeOpener = "opener"
+)

--- a/backend-go/models/artist.go
+++ b/backend-go/models/artist.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+// Artist represents a musical artist or band.
+//
+// Single table for both canonical (MusicBrainz/Spotify/RYM-backed) and
+// user-contributed artists. The difference is whether external IDs are
+// populated and the is_verified flag. When a user-contributed artist later
+// gets canonical backing, just populate the external ID on this row.
+type Artist struct {
+	ID              int        `db:"id" json:"id"`
+	Name            string     `db:"name" json:"name"`
+	MusicBrainzID   *string    `db:"musicbrainz_id" json:"musicbrainz_id,omitempty"`  // maps to GROUP or PERSON
+	SpotifyID       *string    `db:"spotify_id" json:"spotify_id,omitempty"`
+	RYMID           *string    `db:"rym_id" json:"rym_id,omitempty"`
+	ImageURL        *string    `db:"image_url" json:"image_url,omitempty"`
+	IsVerified      bool       `db:"is_verified" json:"is_verified"`
+	CreatedByUserID *int       `db:"created_by_user_id" json:"created_by_user_id,omitempty"`
+	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt       *time.Time `db:"deleted_at" json:"-"`
+}
+

--- a/backend-go/models/concert.go
+++ b/backend-go/models/concert.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// Concert represents a show/event that a user attends.
+//
+// ArtistID is a convenience denormalization for the common case (solo/headliner).
+// For multi-artist events (festivals, album concerts),
+// ArtistID is NULL and the acts table is the source of truth for who performed.
+//
+// The acts table always holds the full picture. ArtistID is a shortcut to
+// avoid a JOIN when listing concerts with their main artist. Setlist.fm models
+// it similarly: one setlist = one artist, with festivals having separate entries.
+//
+// Solo show:     ArtistID set + 1 act
+// Multi-artist:  ArtistID NULL + N acts (each with act_type: main, opener, etc.)
+type Concert struct {
+	ID          int        `db:"id" json:"id"`
+	Name        *string    `db:"name" json:"name,omitempty"`
+	Date        time.Time  `db:"date" json:"date"`
+
+	VenueID     *int       `db:"venue_id" json:"venue_id,omitempty"`
+	ArtistID    *int       `db:"artist_id" json:"artist_id,omitempty"` // main/primary artist, nullable for multi-artist
+	SetlistFmID *string    `db:"setlistfm_id" json:"setlistfm_id,omitempty"`
+
+	CreatedAt   time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt   *time.Time `db:"deleted_at" json:"-"`
+}
+

--- a/backend-go/models/song.go
+++ b/backend-go/models/song.go
@@ -1,0 +1,30 @@
+package models
+
+import "time"
+
+// Song represents a musical track/composition.
+//
+// ArtistID refers to the original/credited artist (songwriter or recording
+// artist), NOT the performer at a specific concert. Performance context comes
+// from the Act that the video is linked to:
+//
+//	video -> act -> artist = who performed it
+//	video -> song -> artist = who wrote/recorded it
+//
+// therefore when song.artist_id != act.artist_id, it's a cover
+type Song struct {
+	ID                     int        `db:"id" json:"id"`
+	Title                  string     `db:"title" json:"title"`
+	ArtistID               int        `db:"artist_id" json:"artist_id"`
+	DurationSeconds        *int       `db:"duration_seconds" json:"duration_seconds,omitempty"`
+
+	MusicBrainzRecordingID *string    `db:"musicbrainz_recording_id" json:"musicbrainz_recording_id,omitempty"`
+	ISRC                   *string    `db:"isrc" json:"isrc,omitempty"`
+
+	IsVerified             bool       `db:"is_verified" json:"is_verified"`
+	CreatedByUserID        *int       `db:"created_by_user_id" json:"created_by_user_id,omitempty"`
+
+	CreatedAt              time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt              *time.Time `db:"deleted_at" json:"-"`
+}
+

--- a/backend-go/models/venue.go
+++ b/backend-go/models/venue.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+type Venue struct {
+	ID        int        `db:"id" json:"id"`
+	Name      string     `db:"name" json:"name"`
+	
+	Latitude    *float64   `db:"latitude" json:"latitude,omitempty"`
+  	Longitude   *float64   `db:"longitude" json:"longitude,omitempty"`
+
+	City        *string    `db:"city" json:"city,omitempty"`
+	Region      *string    `db:"region" json:"region,omitempty"` // state/province/etc
+	CountryCode string     `db:"country_code" json:"country_code"` // CA/US/KR
+
+	Address     *string    `db:"address" json:"address,omitempty"`
+	GooglePlaceID *string `db:"google_place_id" json:"google_place_id,omitempty"`
+
+	CreatedAt time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt *time.Time `db:"deleted_at" json:"-"`
+}

--- a/backend-go/models/video.go
+++ b/backend-go/models/video.go
@@ -16,7 +16,9 @@ type Video struct {
 	Visibility   string     `db:"visibility" json:"visibility"`
 
 	EventType    *string    `db:"event_type" json:"event_type"`
-    EventID      *int       `db:"event_id" json:"event_id"`
+	EventID      *int       `db:"event_id" json:"event_id"`
+	ActID        *int       `db:"act_id" json:"act_id,omitempty"`
+	SongID       *int       `db:"song_id" json:"song_id,omitempty"`
 
 	// metadata (extracted or client-provided)
 	Duration     *float64   `db:"duration" json:"duration"`  // Nullable (in seconds)


### PR DESCRIPTION
Issue: #27 

## TLDR
Implemented a hierarchical music data model (Artists, Songs, Venues, Concerts, Acts) that supports both canonical metadata (MusicBrainz, Spotify, RYM) and community-driven content, while enabling progressive video tagging and implicit cover song detection.

## What Changed & Decisions

### 1. Unified Entity Tables
- **Decision**: Used single tables for `artists` and `songs` instead of separate "canonical" vs "user" tables.
- **Why**: Allows for smooth transition from user-added content to verified status. A niche artist added by a user can be "upgraded" to canonical status later just by populating their MusicBrainz or Spotify IDs.

### 2. The Act Model (Decoupling Performer from Show)
- **Decision**: Introduced the `acts` table as a join between `concerts` and `artists`. Guess the artist with concert with only one act during upload flow, let user one tap confirm. 
- **Why**: Standard "one artist per show" models break for festivals, openers, or battle-of-the-bands. By linking `videos -> acts -> concerts`, we correctly identify the performer even in multi-artist environments.
- **Nuance**: Added `artist_id` to the `concerts` table as a convenience denormalization for solo/headliner shows to avoid expensive joins for simple listings.

### 3. Implicit Cover Detection
- **Decision**: `songs` track the original/credited artist, while `acts` track the performer.
- **Why**: When a video's `song.artist_id` differs from its `act.artist_id`, the system implicitly knows it's a cover. This avoids needing an explicit "is_cover" flag and keeps the data model semantically correct.

### 4. Progressive Video Tagging
- **Decision**: Video relationships are tiered and nullable: `video -> concert (coarse) -> act (medium) -> song (fine)`.
- **Why**: Minimizes user friction. A video is "captured" by a concert match (GPS/Time) automatically. Users can optionally enrich it with the specific artist (Act) and track (Song) later. Any step can be skipped without losing the higher-level context.

### 5. Canonical Source Support
- **Decision**: Integrated MusicBrainz (MBID) as the primary stable identifier.
- **Why**: MBIDs are the industry standard for open metadata (used by Setlist.fm and Last.fm). We also included Spotify and RYM (Sonemic) IDs for cross-platform linking and community relevance.

## Database Schema
- New Tables: `artists`, `songs`, `venues`, `concerts`, `acts`.
- Updated: `videos` table with `act_id` and `song_id` foreign keys.
- Added comprehensive indexing for performance (MBIDs, dates, and polymorphic event lookups).