### PR TITLE
Add song_performances for setlist context

### DIFF
--- a/backend-go/migrations/000008_add_song_performances.down.sql
+++ b/backend-go/migrations/000008_add_song_performances.down.sql
@@ -1,0 +1,10 @@
+-- Revert: drop song_performance_id, restore song_id on videos
+DROP INDEX IF EXISTS idx_videos_song_performance_id;
+ALTER TABLE videos DROP COLUMN IF EXISTS song_performance_id;
+
+ALTER TABLE videos
+    ADD COLUMN song_id INTEGER REFERENCES songs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_videos_song_id ON videos(song_id) WHERE song_id IS NOT NULL;
+
+DROP TABLE IF EXISTS song_performances;

--- a/backend-go/migrations/000008_add_song_performances.up.sql
+++ b/backend-go/migrations/000008_add_song_performances.up.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Add song_performances table, replace videos.song_id with song_performance_id
+-- ============================================================================
+
+CREATE TABLE song_performances (
+    id         SERIAL PRIMARY KEY,
+    act_id     INTEGER NOT NULL REFERENCES acts(id) ON DELETE CASCADE,
+    song_id    INTEGER NOT NULL REFERENCES songs(id) ON DELETE CASCADE,
+    position   INTEGER,           -- position in the setlist (nullable)
+    started_at TIMESTAMP,         -- when the song was performed (nullable)
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_song_performances_act_id ON song_performances(act_id);
+CREATE INDEX idx_song_performances_song_id ON song_performances(song_id);
+
+-- Replace song_id with song_performance_id on videos
+DROP INDEX IF EXISTS idx_videos_song_id;
+ALTER TABLE videos DROP COLUMN IF EXISTS song_id;
+
+ALTER TABLE videos
+    ADD COLUMN song_performance_id INTEGER REFERENCES song_performances(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_videos_song_performance_id ON videos(song_performance_id) WHERE song_performance_id IS NOT NULL;
+

--- a/backend-go/models/song.go
+++ b/backend-go/models/song.go
@@ -5,11 +5,11 @@ import "time"
 // Song represents a musical track/composition.
 //
 // ArtistID refers to the original/credited artist (songwriter or recording
-// artist), NOT the performer at a specific concert. Performance context comes
-// from the Act that the video is linked to:
+// artist), NOT the performer at a specific concert. Performance context is
+// modeled through SongPerformance that the video is linked to.
 //
-//	video -> act -> artist = who performed it
-//	video -> song -> artist = who wrote/recorded it
+//	video -> song_performance -> song -> artist = who wrote/recorded it
+//	video -> song_performance -> act  -> artist = who performed it
 //
 // therefore when song.artist_id != act.artist_id, it's a cover
 type Song struct {

--- a/backend-go/models/song_performance.go
+++ b/backend-go/models/song_performance.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// SongPerformance represents a specific song performed by a specific act.
+//
+// This is where setlist data lives. Grouped by act_id, these rows form the
+// setlist for that act's set. Data can come from Setlist.fm imports or
+// user contributions.
+//
+// Videos link to SongPerformance instead of directly to songs
+//
+
+type SongPerformance struct {
+	ID        int        `db:"id" json:"id"`
+	ActID     int        `db:"act_id" json:"act_id"`
+	SongID    int        `db:"song_id" json:"song_id"`
+	Position  *int       `db:"position" json:"position,omitempty"`   // position in the setlist
+	StartedAt *time.Time `db:"started_at" json:"started_at,omitempty"`
+
+	CreatedAt time.Time  `db:"created_at" json:"created_at"`
+	DeletedAt *time.Time `db:"deleted_at" json:"-"`
+}
+

--- a/backend-go/models/video.go
+++ b/backend-go/models/video.go
@@ -15,10 +15,10 @@ type Video struct {
 	Status       string     `db:"status" json:"status"`
 	Visibility   string     `db:"visibility" json:"visibility"`
 
-	EventType    *string    `db:"event_type" json:"event_type"`
-	EventID      *int       `db:"event_id" json:"event_id"`
-	ActID        *int       `db:"act_id" json:"act_id,omitempty"`
-	SongID       *int       `db:"song_id" json:"song_id,omitempty"`
+	EventType           *string `db:"event_type" json:"event_type"`
+	EventID             *int    `db:"event_id" json:"event_id"`
+	ActID               *int    `db:"act_id" json:"act_id,omitempty"`
+	SongPerformanceID   *int    `db:"song_performance_id" json:"song_performance_id,omitempty"`
 
 	// metadata (extracted or client-provided)
 	Duration     *float64   `db:"duration" json:"duration"`  // Nullable (in seconds)


### PR DESCRIPTION
## What changed?
Added `SongPerformance` model and `song_performances` table. Videos now link to `song_performance_id` instead of `song_id` directly.

## Why?
- Setlist data has a place to live: 1 act + multiple song performances
- Multiple videos of the same performance point to one row

## Note:
A video might span multiple song performances or even multiple acts. Good TODO might be in-app video separating feature.

For MVP we don't have to assign song performance or act. We just need it to go under concert, and that is least viable upload