### PR TITLE
Worker pool and Scheduler foundation for all concurrent features

### DIFF
--- a/backend-go/workers/pool.go
+++ b/backend-go/workers/pool.go
@@ -1,1 +1,74 @@
 package workers
+
+import (
+	"context"
+	"log"
+	"sync"
+	)
+
+// Job represents a unit of work to be processed by the worker pool
+type Job func(context.Context) error
+
+// Pool manages a set of worker goroutines pulled from the job queue
+type Pool struct {
+	name 	 string
+	concurrency int // # of workers
+	queue 	 chan Job // buffered channel to hold pending jobs
+	wg 		 sync.WaitGroup // wait for all goroutines to finish
+	onError  func(error)
+}
+
+// NewPool creates a new worker pool with the given name, concurrency level, and queue size
+func NewPool(name string, concurrency int, queueSize int) *Pool {
+	return &Pool{
+		name: name,
+		concurrency: concurrency,
+		queue: make(chan Job, queueSize),
+		onError: func(err error) { log.Printf("[pool:%s] job error: %v", name, err) }, //TEMP: write with error handler later
+	}
+}
+
+// Run starts the worker pool and blocks until all workers have stopped (when context is finished)
+// This is safe since we are using Postgres-based buffered queue, so we won't lose any jobs if the pool is stopped while processing
+func (p *Pool) Run(ctx context.Context) {
+	log.Printf("[pool:%s] starting with concurrency=%d", p.name, p.concurrency)
+	for i := 0; i < p.concurrency; i++ {
+		p.wg.Add(1)
+		go p.worker(ctx)
+	}
+	p.wg.Wait()
+	log.Printf("[pool:%s] all workers stopped", p.name)
+}
+
+// worker is the function run by each worker goroutine to process jobs from the queue
+func (p *Pool) worker(ctx context.Context) {
+	defer p.wg.Done() // clean up when worker exits
+	for {
+		select {
+		case <- ctx.Done(): // stop worker if ctx is finished
+			log.Printf("[pool:%s] worker stopping due to context done", p.name)
+			return
+		case job := <- p.queue: // get next job from queue 
+			if err := job(ctx); err != nil && p.onError != nil {
+				p.onError(err)
+			}
+		}
+	}
+}
+
+// Submit adds a new job to the pool's queue. Returns false if the context is done before the job can be submitted.
+func (p *Pool) Submit(ctx context.Context, job Job) bool {
+	select { 
+	case p.queue <- job: // submit job to queue
+		log.Printf("[pool:%s] job submitted", p.name)
+		return true
+	case <- ctx.Done(): // stop submitting if ctx is finished
+		log.Printf("[pool:%s] failed to submit job: context done", p.name)
+		return false
+	}
+}
+
+// Available returns the number of available slots in the queue (used as a hint for when to submit new jobs)
+func (p *Pool) Available() int {
+	return cap(p.queue) - len(p.queue)
+}

--- a/backend-go/workers/scheduler.go
+++ b/backend-go/workers/scheduler.go
@@ -1,0 +1,77 @@
+package workers
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// FetchFunc is a function type that defines how to fetch jobs for the scheduler. 
+// It takes a context and a limit on how many jobs to fetch, and returns a slice of jobs and an error if any.
+type FetchFunc func (ctx context.Context, limit int) ([]Job, error)
+
+// Scheduler polls for work at a fixed interval and submits jobs to a Pool.
+type Scheduler struct {
+	name string
+	pool *Pool
+	fetch FetchFunc
+	interval time.Duration
+}
+
+// NewScheduler creates a new Scheduler with the given name, worker pool, fetch function, and polling interval.
+func NewScheduler(name string, pool *Pool, fetch FetchFunc, interval time.Duration) *Scheduler {
+	return &Scheduler{
+		name: name,
+		pool: pool,
+		fetch: fetch,
+		interval: interval,
+	}
+}
+
+// Run starts the polling loop of the scheduler. It polls for jobs at the interval rate, submits to pool until context is done. 
+// This is safe since we are using Postgres-based buffered queue, so we won't lose any jobs if the scheduler is stopped while processing.
+func (s *Scheduler) Run(ctx context.Context) {
+	log.Printf("[scheduler:%s] starting with interval=%s", s.name, s.interval)
+	
+	s.poll(ctx) // run immediately on start
+
+	ticker := time.NewTicker(s.interval)
+	log.Printf("[scheduler:%s] ticker started with interval=%s", s.name, s.interval)
+	defer ticker.Stop()
+
+	for {
+		select { // same select pattern as worker pool to allow graceful shutdown when context is done
+		case <- ctx.Done():
+			log.Printf("[scheduler:%s] stopping", s.name)
+			return
+		case <- ticker.C:
+			s.poll(ctx)
+			log.Printf("[scheduler:%s] poll complete", s.name)
+		}
+	}
+	
+}
+
+// Poll checks available pool capacity, fetches work accordingly and submits to pool until context is done. 
+// This is safe since we are using Postgres-based buffered queue, so we won't lose any jobs if the scheduler is stopped while processing.
+func (s *Scheduler) poll(ctx context.Context) {
+	available := s.pool.Available()
+	if available <= 0 {
+		log.Printf("[scheduler:%s] no available workers, skipping poll", s.name)
+		return
+	}
+
+	jobs, err := s.fetch(ctx, available)
+	if err != nil {
+		log.Printf("[scheduler:%s] error fetching jobs: %v", s.name, err)
+		return
+	}
+
+	for _, job := range jobs {
+		if !s.pool.Submit(ctx, job) { // if context is done while submitting, stop submitting more jobs
+			log.Printf("[scheduler:%s] context done while submitting job, stopping", s.name)
+			return
+		}
+	}
+	log.Printf("[scheduler:%s] submitted %d jobs", s.name, len(jobs))
+}


### PR DESCRIPTION
#16 
### Summary
- **`workers/pool.go`** — Generic goroutine pool designed for buffered channel queue.

Written on the premise of a buffered channel to hold pending jobs and `sync.WaitGroup` to wait until all workers (goroutines) are finished in a given pool.

Handles backpressure using a consistent `select` , `case` pattern that stops the worker if ctx is finished and otherwise gets the next job from the job queue.

- **`workers/scheduler.go`** — Reusable polling loop that checks pool capacity, fetches work via a pluggable `FetchFunc`, and submits jobs to the pool

The scheduler polls for jobs at a fixed interval rate and constantly submits to the pool by checking the available pool capacity and fetching work using the `FetchFunc` from the Postgres job queue until the context terminates.


### Design
Every future concurrent feature (video processing, MusicBrainz sync, etc.) follows the same pattern: define a `FetchFunc`, create a `Pool` + `Scheduler`, wire in `main.go`. The workers package stays domain-agnostic (there are no dependencies on any service or handlers)

Job queue is Postgres-backed (`FOR UPDATE SKIP LOCKED` in the fetch function). Postgres handles the thread safety and ensures that, on failure, no jobs are lost.