### PR TITLE
Implement dev auth bypass, restructure route groups in main.go

### DIFF
--- a/backend-go/config/config.go
+++ b/backend-go/config/config.go
@@ -2,14 +2,17 @@ package config
 
 import (
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
 
 type Config struct {
-	Port        string
-	Environment string
-	DatabaseURL string
+	Port          string
+	Environment   string
+	DatabaseURL   string
+	DevBypassAuth bool
+	DevAuth0ID    string
 
 	Auth0  Auth0Config
 	Spaces SpacesConfig
@@ -33,9 +36,11 @@ func Load() *Config {
 	godotenv.Load()
 
 	return &Config{
-		Port:        getEnv("PORT", "8081"),
-		Environment: getEnv("ENVIRONMENT", "development"),
-		DatabaseURL: getEnv("DATABASE_URL", ""),
+		Port:          getEnv("PORT", "8081"),
+		Environment:   getEnv("ENVIRONMENT", "development"),
+		DatabaseURL:   getEnv("DATABASE_URL", ""),
+		DevBypassAuth: getEnvBool("DEV_BYPASS_AUTH", false),
+		DevAuth0ID:    getEnv("DEV_AUTH0_ID", ""),
 
 		Auth0: Auth0Config{
 			Domain:   getEnv("AUTH0_DOMAIN", ""),
@@ -58,4 +63,19 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if value == "" {
+		return defaultValue
+	}
+	switch value {
+	case "1", "true":
+		return true
+	case "0", "false":
+		return false
+	default:
+		return defaultValue
+	}
 }

--- a/backend-go/middleware/auth.go
+++ b/backend-go/middleware/auth.go
@@ -32,7 +32,7 @@ func AuthRequired(auth0 config.Auth0Config) gin.HandlerFunc {
 		validator.WithAllowedClockSkew(time.Minute), // allow small clock differences when checking exp/nbf/iat
 	)
 	if err != nil {
-		log.Fatalf("Failed to set up the jwt validator: %w", err)
+		log.Fatalf("Failed to set up the jwt validator: %v", err)
 	}
 
 	return func(c *gin.Context) {

--- a/backend-go/middleware/dev_auth.go
+++ b/backend-go/middleware/dev_auth.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DevAuthBypass injects auth0_id in local development so protected routes can
+// be hit without obtaining a real JWT.
+func DevAuthBypass(defaultAuth0ID string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("auth0_id", strings.TrimSpace(defaultAuth0ID))
+		c.Next()
+	}
+}


### PR DESCRIPTION
#35 

## What changed?
- Added a local auth bypass path controlled by env (`DEV_BYPASS_AUTH`, `DEV_AUTH0_ID`), with startup validation.
- Kept JWT auth as default; bypass is only allowed in development.
- Reworked route wiring so routes are grouped by resource (`/users`, `/videos`) with clear public vs auth+resolved behavior.
- Added `ResolveUser` on routes that require DB user context (e.g., `/users/me`, video write endpoints).
- Kept video read endpoints public (`GET /videos`, `GET /videos/:id`).

## Why make this change?
- Makes local feature testing fast without full auth setup.
- Makes route auth requirements easier to read and maintain.

## To use this:
DEV_BYPASS_AUTH=true
DEV_AUTH0_ID=test user auth0 id <- redacted