### PR TITLE
Add search endpoints for artists and songs

### DIFF
--- a/backend-go/database/store_artists.go
+++ b/backend-go/database/store_artists.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"context"
+	"errors"
+
+	"github.com/areeeeeeeb/reLive/backend-go/apperr"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/jackc/pgx/v5"
+)
+
+const artistCols = `
+	id,
+	name,
+	musicbrainz_id,
+	spotify_id,
+	rym_id,
+	image_url,
+	is_verified,
+	created_by_user_id,
+	created_at,
+	deleted_at
+`
+
+func scanArtist(row pgx.Row) (*models.Artist, error) {
+	var a models.Artist
+	err := row.Scan(
+		&a.ID,
+		&a.Name,
+		&a.MusicBrainzID,
+		&a.SpotifyID,
+		&a.RYMID,
+		&a.ImageURL,
+		&a.IsVerified,
+		&a.CreatedByUserID,
+		&a.CreatedAt,
+		&a.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, apperr.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func scanArtists(rows pgx.Rows) ([]models.Artist, error) {
+	var artists []models.Artist
+	for rows.Next() {
+		a, err := scanArtist(rows)
+		if err != nil {
+			return nil, err
+		}
+		artists = append(artists, *a)
+	}
+	return artists, rows.Err()
+}
+
+func (s *Store) GetArtistByID(ctx context.Context, id int) (*models.Artist, error) {
+	const q = `
+	SELECT ` + artistCols + `
+	FROM artists
+	WHERE id = $1 AND deleted_at IS NULL`
+
+	return scanArtist(s.pool.QueryRow(ctx, q, id))
+}
+
+func (s *Store) SearchArtists(ctx context.Context, query string, maxResults int) ([]models.Artist, error) {
+	const q = `
+	SELECT ` + artistCols + `
+	FROM artists
+	WHERE name ILIKE $1 AND deleted_at IS NULL
+	ORDER BY is_verified DESC, name ASC
+	LIMIT $2`
+
+	// TODO: better search ranking system
+
+	rows, err := s.pool.Query(ctx, q, "%"+escapeILIKE(query)+"%", maxResults) // TODO: use elasticsearch
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanArtists(rows)
+}

--- a/backend-go/database/store_songs.go
+++ b/backend-go/database/store_songs.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"context"
+	"errors"
+
+	"github.com/areeeeeeeb/reLive/backend-go/apperr"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/jackc/pgx/v5"
+)
+
+const songCols = `
+	id,
+	title,
+	artist_id,
+	artist_name_raw,
+	duration_seconds,
+	musicbrainz_recording_id,
+	isrc,
+	is_verified,
+	created_by_user_id,
+	created_at,
+	deleted_at
+`
+
+func scanSong(row pgx.Row) (*models.Song, error) {
+	var s models.Song
+	err := row.Scan(
+		&s.ID,
+		&s.Title,
+		&s.ArtistID,
+		&s.ArtistNameRaw,
+		&s.DurationSeconds,
+		&s.MusicBrainzRecordingID,
+		&s.ISRC,
+		&s.IsVerified,
+		&s.CreatedByUserID,
+		&s.CreatedAt,
+		&s.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, apperr.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func scanSongs(rows pgx.Rows) ([]models.Song, error) {
+	var songs []models.Song
+	for rows.Next() {
+		s, err := scanSong(rows)
+		if err != nil {
+			return nil, err
+		}
+		songs = append(songs, *s)
+	}
+	return songs, rows.Err()
+}
+
+func (s *Store) GetSongByID(ctx context.Context, id int) (*models.Song, error) {
+	const q = `
+	SELECT ` + songCols + `
+	FROM songs
+	WHERE id = $1 AND deleted_at IS NULL`
+
+	return scanSong(s.pool.QueryRow(ctx, q, id))
+}
+
+func (s *Store) SearchSongs(ctx context.Context, query string, maxResults int) ([]models.Song, error) {
+	const q = `
+	SELECT ` + songCols + `
+	FROM songs
+	WHERE title ILIKE $1 AND deleted_at IS NULL
+	ORDER BY is_verified DESC, title ASC
+	LIMIT $2`
+
+	// TODO: better search ranking system
+
+	rows, err := s.pool.Query(ctx, q,  "%"+escapeILIKE(query)+"%", maxResults) // TODO: use elasticsearch
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+
+	return scanSongs(rows)
+}

--- a/backend-go/database/util.go
+++ b/backend-go/database/util.go
@@ -1,0 +1,11 @@
+package database
+
+import "strings"
+
+// escapeILIKE escapes special ILIKE wildcard characters (% and _)
+func escapeILIKE(s string) string {
+    s = strings.ReplaceAll(s, `\`, `\\`)
+    s = strings.ReplaceAll(s, `%`, `\%`)
+    s = strings.ReplaceAll(s, `_`, `\_`)
+    return s
+}

--- a/backend-go/handlers/artist_handler.go
+++ b/backend-go/handlers/artist_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/areeeeeeeb/reLive/backend-go/apperr"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/services"
+	"github.com/gin-gonic/gin"
+)
+
+type ArtistHandler struct {
+	artistService *services.ArtistService
+}
+
+func NewArtistHandler(artistService *services.ArtistService) *ArtistHandler {
+	return &ArtistHandler{artistService: artistService}
+}
+
+//	GET /artists/:id
+func (h *ArtistHandler) Get(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid artist id"})
+		return
+	}
+
+	artist, err := h.artistService.Get(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, apperr.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "artist not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get artist"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"artist": artist})
+}
+
+// Search returns artists matching a query string.
+//
+//	GET /artists/search?q=radiohead&max_results=10&source=mixed
+// default (main) behavior is to search both local and external sources
+// this can be overridden by setting the source query parameter
+func (h *ArtistHandler) Search(c *gin.Context) {
+	var req models.SearchRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.MaxResults <= 0 {
+		req.MaxResults = models.SearchMaxResultsDefault
+	}
+	if req.MaxResults > models.SearchMaxResultsMax {
+		req.MaxResults = models.SearchMaxResultsMax
+	}
+	if req.Source == "" {
+		req.Source = models.SearchDefaultSource
+	}
+
+	artists, err := h.artistService.Search(c.Request.Context(), req.Q, req.MaxResults, req.Source)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "artist search failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"artists": artists})
+}

--- a/backend-go/handlers/song_handler.go
+++ b/backend-go/handlers/song_handler.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/areeeeeeeb/reLive/backend-go/apperr"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/services"
+	"github.com/gin-gonic/gin"
+)
+
+type SongHandler struct {
+	songService *services.SongService
+}
+
+func NewSongHandler(songService *services.SongService) *SongHandler {
+	return &SongHandler{songService: songService}
+}
+
+// Get returns a single song by ID.
+//
+//	GET /songs/:id
+func (h *SongHandler) Get(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid song id"})
+		return
+	}
+
+	song, err := h.songService.Get(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, apperr.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "song not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get song"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"song": song})
+}
+
+// Search returns songs matching a query string.
+//
+//	GET /songs/search?q=creep&max_results=10&source=mixed
+// default (main) behavior is to search both local and external sources
+// this can be overridden by setting the source query parameter
+func (h *SongHandler) Search(c *gin.Context) {
+	var req models.SearchRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.MaxResults <= 0 {
+		req.MaxResults = models.SearchMaxResultsDefault
+	}
+	if req.MaxResults > models.SearchMaxResultsMax {
+		req.MaxResults = models.SearchMaxResultsMax
+	}
+	if req.Source == "" {
+		req.Source = models.SearchDefaultSource
+	}
+
+	songs, err := h.songService.Search(c.Request.Context(), req.Q, req.MaxResults, req.Source)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "song search failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"songs": songs})
+}

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -71,6 +71,9 @@ func main() {
 	// add service structs here
 	userService := services.NewUserService(store)
 	videoService := services.NewVideoService(store, s3Client, cfg.Spaces.Bucket, cfg.Spaces.CdnURL)
+	searchService := services.NewSearchService()
+	artistService := services.NewArtistService(store, searchService)
+	songService := services.NewSongService(store, searchService)
 	// mediaService, err := services.NewMediaService()
 	// if err != nil {
 	// 	log.Fatalf("Failed to create media service %v", err)
@@ -79,6 +82,8 @@ func main() {
 	// add handler structs here
 	userHandler := handlers.NewUserHandler(userService)
 	videoHandler := handlers.NewVideoHandler(videoService)
+	artistHandler := handlers.NewArtistHandler(artistService)
+	songHandler := handlers.NewSongHandler(songService)
 
 	// Basic health check endpoint
 	r.GET("/health", func(c *gin.Context) {
@@ -136,6 +141,20 @@ func main() {
 				videosResolved.POST("/:id/upload/confirm", videoHandler.UploadConfirm)
 				videosResolved.DELETE("/:id", videoHandler.Delete)
 			}
+		}
+
+		// artists routes
+		artists := v2.Group("/artists")
+		{
+			artists.GET("/search", artistHandler.Search)
+			artists.GET("/:id", artistHandler.Get)
+		}
+
+		// songs routes
+		songs := v2.Group("/songs")
+		{
+			songs.GET("/search", songHandler.Search)
+			songs.GET("/:id", songHandler.Get)
 		}
 	}
 

--- a/backend-go/migrations/000010_allow_unresolved_songs.down.sql
+++ b/backend-go/migrations/000010_allow_unresolved_songs.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE songs
+    DROP CONSTRAINT IF EXISTS songs_verified_requires_artist_chk,
+    DROP COLUMN IF EXISTS artist_name_raw;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM songs WHERE artist_id IS NULL) THEN
+        RAISE EXCEPTION 'cannot set songs.artist_id back to NOT NULL while unresolved songs exist';
+    END IF;
+END $$;
+
+ALTER TABLE songs
+    ALTER COLUMN artist_id SET NOT NULL;

--- a/backend-go/migrations/000010_allow_unresolved_songs.up.sql
+++ b/backend-go/migrations/000010_allow_unresolved_songs.up.sql
@@ -1,0 +1,11 @@
+-- ============================================================================
+-- Allow unresolved songs with raw artist text
+-- ============================================================================
+
+ALTER TABLE songs
+    ALTER COLUMN artist_id DROP NOT NULL,
+    ADD COLUMN artist_name_raw VARCHAR(255);
+
+ALTER TABLE songs
+    ADD CONSTRAINT songs_verified_requires_artist_chk
+        CHECK (NOT is_verified OR artist_id IS NOT NULL);

--- a/backend-go/models/search_dto.go
+++ b/backend-go/models/search_dto.go
@@ -1,0 +1,23 @@
+package models
+
+const (
+	SearchSourceLocal    = "local"
+	SearchSourceExternal = "external"
+	SearchSourceMixed    = "mixed"
+)
+
+const (
+	SearchMaxResultsDefault = 10
+	SearchMaxResultsMax     = 50
+)
+
+const (
+	SearchDefaultSource = SearchSourceLocal
+)
+
+// SearchRequest for searching any entity via flyout/search bar.
+type SearchRequest struct {
+	Q          string `form:"q" binding:"required"`
+	MaxResults int    `form:"max_results"`
+	Source     string `form:"source" binding:"omitempty,oneof=local external mixed"`
+}

--- a/backend-go/models/song.go
+++ b/backend-go/models/song.go
@@ -15,7 +15,8 @@ import "time"
 type Song struct {
 	ID                     int        `db:"id" json:"id"`
 	Title                  string     `db:"title" json:"title"`
-	ArtistID               int        `db:"artist_id" json:"artist_id"`
+	ArtistID               *int       `db:"artist_id" json:"artist_id,omitempty"`
+	ArtistNameRaw          *string    `db:"artist_name_raw" json:"artist_name_raw,omitempty"`
 	DurationSeconds        *int       `db:"duration_seconds" json:"duration_seconds,omitempty"`
 
 	MusicBrainzRecordingID *string    `db:"musicbrainz_recording_id" json:"musicbrainz_recording_id,omitempty"`
@@ -27,4 +28,3 @@ type Song struct {
 	CreatedAt              time.Time  `db:"created_at" json:"created_at"`
 	DeletedAt              *time.Time `db:"deleted_at" json:"-"`
 }
-

--- a/backend-go/services/artist_service.go
+++ b/backend-go/services/artist_service.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/areeeeeeeb/reLive/backend-go/database"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+)
+
+type ArtistService struct {
+	store         *database.Store
+	searchService *SearchService
+}
+
+func NewArtistService(store *database.Store, searchService *SearchService) *ArtistService {
+	return &ArtistService{store: store, searchService: searchService}
+}
+
+func (s *ArtistService) Get(ctx context.Context, id int) (*models.Artist, error) {
+	return s.store.GetArtistByID(ctx, id)
+}
+
+func (s *ArtistService) Search(ctx context.Context, query string, maxResults int, source string) ([]models.Artist, error) {
+	if err := s.searchService.ValidateMaxResults(maxResults); err != nil {
+		return nil, err
+	}
+
+	switch source {
+	case models.SearchSourceLocal:
+		return s.store.SearchArtists(ctx, query, maxResults)
+	case models.SearchSourceExternal:
+		return nil, fmt.Errorf("external source not implemented for artists")
+	case models.SearchSourceMixed:
+		return nil, fmt.Errorf("mixed source not implemented for artists")
+	default:
+		return nil, fmt.Errorf("invalid source: %s", source)
+	}
+}

--- a/backend-go/services/search_service.go
+++ b/backend-go/services/search_service.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+)
+
+// SearchService is a shared toolkit for search operations.
+// It holds the future MusicBrainz client and shared helpers.
+// Domain services (ArtistService, SongService) own their own search orchestration.
+type SearchService struct {
+	// TODO: add MusicBrainz HTTP client here
+}
+
+func NewSearchService() *SearchService {
+	return &SearchService{}
+}
+
+// ValidateMaxResults checks that maxResults is within allowed bounds.
+func (s *SearchService) ValidateMaxResults(maxResults int) error {
+	if maxResults <= 0 || maxResults > models.SearchMaxResultsMax {
+		return fmt.Errorf("invalid max_results: %d (must be 1-%d)", maxResults, models.SearchMaxResultsMax)
+	}
+	return nil
+}
+
+
+// PAUSED DUE TO MUSICBRAINZ RATE LIMITING CONCERNS
+// FetchMBArtists(ctx, query) ([]MBArtistResult, error)
+// FetchMBRecordings(ctx, query) ([]MBRecordingResult, error)

--- a/backend-go/services/song_service.go
+++ b/backend-go/services/song_service.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/areeeeeeeb/reLive/backend-go/database"
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+)
+
+type SongService struct {
+	store         *database.Store
+	searchService *SearchService
+}
+
+func NewSongService(store *database.Store, searchService *SearchService) *SongService {
+	return &SongService{store: store, searchService: searchService}
+}
+
+func (s *SongService) Get(ctx context.Context, id int) (*models.Song, error) {
+	return s.store.GetSongByID(ctx, id)
+}
+
+func (s *SongService) Search(ctx context.Context, query string, maxResults int, source string) ([]models.Song, error) {
+	if err := s.searchService.ValidateMaxResults(maxResults); err != nil {
+		return nil, err
+	}
+
+	switch source {
+	case models.SearchSourceLocal:
+		return s.store.SearchSongs(ctx, query, maxResults)
+	case models.SearchSourceExternal:
+		return nil, fmt.Errorf("external source not implemented for songs")
+	case models.SearchSourceMixed:
+		return nil, fmt.Errorf("mixed source not implemented for songs")
+	default:
+		return nil, fmt.Errorf("invalid source: %s", source)
+	}
+}


### PR DESCRIPTION
#28 

## What changed?
- Added new read/search API surface for music entities, wired handles/services
  - `GET /v2/artists/:id` `GET /v2/artists/search`
  - `GET /v2/songs/:id`, `GET /v2/songs/search`
- Added `util.go` to database package, added `ILIKE` escaping helper.
- Updated `Song` model to support unresolved songs, added migration
  - `artist_id` is now nullable (`*int`)
  - new optional `artist_name_raw`  <- user will enter this, doesn't have to be exactly correct

## Decisions
`local`, `external`, and `mixed` search query param to search both local db and external api and merge results. Due to rate limiting of MusicBrainz, we will only implement/enable `local` for now (this is default).

Decided to have some repeated code in `artist_service.go` and `song_service.go` for searching, as is it possible that the search logic diverges from each other. For now `search_service.go` will only take care of MusicBrainz and shared helpers.