### PR TITLE
Move Job Queue Worker Pool (video processing) to be parallel with video upload

### DIFF
--- a/backend-go/handlers/video_handler.go
+++ b/backend-go/handlers/video_handler.go
@@ -89,7 +89,7 @@ func (h *VideoHandler) UploadConfirm(c *gin.Context) {
 
 	c.JSON(200, models.UploadConfirmResponse{
 		VideoID: videoID,
-		Status:  models.VideoStatusQueued,
+		Status:  models.VideoStatusCompleted,
 	})
 }
 

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -80,7 +80,7 @@ func main() {
 	artistHandler := handlers.NewArtistHandler(artistService)
 	songHandler := handlers.NewSongHandler(songService)
 
-	// start job queue for pipeline A (concert/song detection)
+	// start job queue for video processing pipeline
 	processingService := services.NewProcessingService(store)
 	jobQueue := services.NewJobQueueService(store, processingService, cfg.Concurrency.Concurrency, cfg.Concurrency.QueueSize, cfg.Concurrency.Interval, cfg.Concurrency.StuckThreshold)
 	jobQueue.Start(ctx)

--- a/backend-go/migrations/000013_add_detection_status.down.sql
+++ b/backend-go/migrations/000013_add_detection_status.down.sql
@@ -1,4 +1,0 @@
-DROP INDEX IF EXISTS idx_videos_pending_detection;
-
-ALTER TABLE videos
-    DROP COLUMN IF EXISTS detection_status;

--- a/backend-go/migrations/000013_add_detection_status.up.sql
+++ b/backend-go/migrations/000013_add_detection_status.up.sql
@@ -1,8 +1,0 @@
-ALTER TABLE videos
-    ADD COLUMN detection_status TEXT DEFAULT NULL;
-
--- detection_status is omitted from the index columns because the WHERE clause already
--- pins this index to only 'pending' rows — including it would be redundant.
-CREATE INDEX idx_videos_pending_detection
-    ON videos (created_at, id)
-    WHERE detection_status = 'pending' AND deleted_at IS NULL;

--- a/backend-go/migrations/000013_add_processing_status.down.sql
+++ b/backend-go/migrations/000013_add_processing_status.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_videos_queued_processing;
+
+ALTER TABLE videos
+    DROP COLUMN IF EXISTS processing_status;

--- a/backend-go/migrations/000013_add_processing_status.up.sql
+++ b/backend-go/migrations/000013_add_processing_status.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE videos
+    ADD COLUMN processing_status TEXT DEFAULT NULL;
+
+-- processing_status is omitted from the index columns because the WHERE clause already
+-- pins this index to only 'queued' rows — including it would be redundant.
+CREATE INDEX idx_videos_queued_processing
+    ON videos (created_at, id)
+    WHERE processing_status = 'queued' AND deleted_at IS NULL;

--- a/backend-go/models/video.go
+++ b/backend-go/models/video.go
@@ -28,7 +28,7 @@ type Video struct {
     Width        *int       `db:"width" json:"width"`
     Height       *int       `db:"height" json:"height"`
 
-	DetectionStatus *string    `db:"detection_status" json:"detection_status,omitempty"`
+	ProcessingStatus *string    `db:"processing_status" json:"processing_status,omitempty"`
 
 	CreatedAt    time.Time  `db:"created_at" json:"created_at"`
 	UpdatedAt    time.Time  `db:"updated_at" json:"updated_at"`
@@ -36,11 +36,9 @@ type Video struct {
 	DeletedAt    *time.Time `db:"deleted_at" json:"-"` // Nullable
 }
 
-// Video status constants
+// Video upload status constants
 const (
 	VideoStatusPendingUpload = "pending_upload"
-	VideoStatusQueued        = "queued"
-	VideoStatusProcessing    = "processing"
 	VideoStatusCompleted     = "completed"
 	VideoStatusFailed        = "failed"
 )
@@ -54,12 +52,12 @@ const (
 	EventTypeConcert = "concert"
 )
 
-// DetectionStatus constants — tracks pipeline A (concert/song detection) independently of upload status
+// Video processing status constants — tracks the processing pipeline independently of upload status
 const (
-	VideoDetectionStatusPending    = "pending"
-	VideoDetectionStatusProcessing = "processing"
-	VideoDetectionStatusCompleted  = "completed"
-	VideoDetectionStatusFailed     = "failed"
+	VideoProcessingStatusQueued     = "queued"
+	VideoProcessingStatusProcessing = "processing"
+	VideoProcessingStatusCompleted  = "completed"
+	VideoProcessingStatusFailed     = "failed"
 )
 
 // VideoMetadata extracted from video file.

--- a/backend-go/models/video_dto.go
+++ b/backend-go/models/video_dto.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 // UploadInitRequest for initiating a multipart upload.
-// Metadata fields are optional — if provided, pipeline A (concert/song detection) starts immediately.
+// Metadata fields are optional — if provided, the processing pipeline starts immediately.
 type UploadInitRequest struct {
 	Filename    string `json:"filename" binding:"required"`
 	ContentType string `json:"contentType" binding:"required"`

--- a/backend-go/services/job_queue_service.go
+++ b/backend-go/services/job_queue_service.go
@@ -10,8 +10,8 @@ import (
 	"github.com/areeeeeeeb/reLive/backend-go/workers"
 )
 
-// JobQueueService manages pipeline A: concert/song detection from client metadata.
-// Completely decoupled from the upload pipeline — claims videos with detection_status = 'pending'
+// JobQueueService manages the processing pipeline: claims queued videos and runs processing jobs.
+// Completely decoupled from the upload pipeline — claims videos with processing_status = 'queued'
 // regardless of upload status.
 type JobQueueService struct {
 	store          *database.Store
@@ -25,11 +25,11 @@ func NewJobQueueService(store *database.Store, processing *ProcessingService, co
 	jqs := &JobQueueService{
 		store:          store,
 		processing:     processing,
-		pool:           workers.NewPool("detection", concurrency, queueSize),
+		pool:           workers.NewPool("processing", concurrency, queueSize),
 		stuckThreshold: stuckThresholdMins,
 	}
 
-	jqs.scheduler = workers.NewScheduler("detection", jqs.pool, jqs.fetch, time.Duration(intervalSecs)*time.Second)
+	jqs.scheduler = workers.NewScheduler("processing", jqs.pool, jqs.fetch, time.Duration(intervalSecs)*time.Second)
 
 	return jqs
 }
@@ -41,32 +41,32 @@ func (jqs *JobQueueService) Start(ctx context.Context) {
 	log.Println("[job-queue] started")
 }
 
-// fetch bridges Postgres → worker jobs for pipeline A (detection).
-// Also resets videos stuck in detection_status = 'processing' on every tick,
+// fetch bridges Postgres → worker jobs for the processing pipeline.
+// Also resets videos stuck in processing_status = 'processing' on every tick,
 // so crashed workers are recovered without requiring a server restart.
 func (jqs *JobQueueService) fetch(ctx context.Context, limit int) ([]workers.Job, error) {
-	if err := jqs.store.ResetStuckDetectingVideos(ctx, time.Duration(jqs.stuckThreshold)*time.Minute); err != nil {
-		log.Printf("[job-queue] failed to reset stuck detections: %v", err)
+	if err := jqs.store.ResetStuckProcessingVideos(ctx, time.Duration(jqs.stuckThreshold)*time.Minute); err != nil {
+		log.Printf("[job-queue] failed to reset stuck processing jobs: %v", err)
 	}
 
-	videos, err := jqs.store.ClaimPendingDetections(ctx, limit)
+	videos, err := jqs.store.ClaimQueuedProcessing(ctx, limit)
 	if err != nil {
 		return nil, err
 	}
 
 	jobs := make([]workers.Job, len(videos))
 	for i, v := range videos {
-		jobs[i] = jqs.detectionJob(v)
+		jobs[i] = jqs.processingJob(v)
 	}
 	return jobs, nil
 }
 
-// detectionJob returns a Job that runs concert/song detection for a single video.
-func (jqs *JobQueueService) detectionJob(v *models.Video) workers.Job {
+// processingJob returns a Job that runs the processing pipeline for a single video.
+func (jqs *JobQueueService) processingJob(v *models.Video) workers.Job {
 	return func(ctx context.Context) error {
 		if err := jqs.processing.Process(ctx, v); err != nil {
-			if ferr := jqs.store.FailDetection(ctx, v.ID); ferr != nil {
-				log.Printf("[job-queue] video %d: failed to mark detection as failed: %v", v.ID, ferr)
+			if ferr := jqs.store.SetProcessingStatusFailed(ctx, v.ID); ferr != nil {
+				log.Printf("[job-queue] video %d: failed to mark processing as failed: %v", v.ID, ferr)
 			}
 			return err
 		}

--- a/backend-go/services/processing_service.go
+++ b/backend-go/services/processing_service.go
@@ -15,12 +15,12 @@ func NewProcessingService(store *database.Store) *ProcessingService {
 	return &ProcessingService{store: store}
 }
 
-// Process runs pipeline A: concert/song detection using client-provided metadata on the video.
-// Called by JobQueueService for videos with detection_status = 'processing'.
-// On success, marks detection_status = 'completed'. On failure, JobQueueService marks it 'failed'.
+// Process runs the processing pipeline using client-provided metadata on the video.
+// Called by JobQueueService for videos with processing_status = 'processing'.
+// On success, marks processing_status = 'completed'. On failure, JobQueueService marks it 'failed'.
 func (ps *ProcessingService) Process(ctx context.Context, video *models.Video) error {
 	// step 1: concert detection via external API using video.Latitude, video.Longitude, video.RecordedAt
 	// step 2: song/artist detection using concert + local source of truth or external API
-	// step 3: store.CompleteDetection(ctx, video.ID)
-	return ps.store.CompleteDetection(ctx, video.ID)
+	// step 3: store.SetProcessingStatusCompleted(ctx, video.ID)
+	return ps.store.SetProcessingStatusCompleted(ctx, video.ID)
 }

--- a/backend-go/services/video_service.go
+++ b/backend-go/services/video_service.go
@@ -104,8 +104,8 @@ func (s *VideoService) ConfirmUpload(ctx context.Context, videoID int, userID in
 		return fmt.Errorf("failed to complete S3 upload: %w", err)
 	}
 
-	// Update video status to queued (ready for processing)
-	if _, err := s.store.UpdateVideoStatus(ctx, videoID, models.VideoStatusQueued); err != nil {
+	// Update video status to completed (upload done)
+	if _, err := s.store.UpdateVideoStatus(ctx, videoID, models.VideoStatusCompleted); err != nil {
 		return fmt.Errorf("failed to update video status: %w", err)
 	}
 


### PR DESCRIPTION
## Pipeline A: Parallel Concert/Song Detection

Begins concert/song detection **while the video is still uploading** using
client-provided metadata (GPS, timestamp, duration, dimensions). Both run
in parallel — no coordination needed.

### Changes

- **Migration 000013** — adds `detection_status TEXT` column: a separate state
  machine from `status` (`pending → processing → completed/failed`), `NULL` when
  no client metadata. Partial index on `(created_at, id)` for pending rows.

- **`UploadInitRequest`** — new optional fields: `recordedAt`, `latitude`,
  `longitude`, `duration`, `width`, `height`

- **`CreateVideo`** — stores metadata at init time; sets `detection_status =
  'pending'` atomically in the INSERT if any metadata is present

- **`JobQueueService`** — rewritten to poll `ClaimPendingDetections`. Stuck reset
  moved from `Start()` to `fetch()` so crashed jobs recover every tick, not just
  at startup. `FailDetection` errors now logged.

- **`ProcessingService.Process()`** — stubbed Pipeline A orchestrator:
  1. Concert detection (GPS + timestamp → external API)
  2. Song/artist detection (concert context → local source of truth or API)
  3. `CompleteDetection`

### Design Decisions

**Separate column, not mixed into `status`** — `ConfirmUpload` needed zero
changes. Two truly independent state machines; a video can be
`status=queued, detection_status=completed` simultaneously.

**Job queue over fire-and-forget goroutine** — survives server restarts (pending
rows stay in Postgres), `FOR UPDATE SKIP LOCKED` prevents double-processing
across workers, controlled concurrency under load.

**Detect at `UploadInit`, not `ConfirmUpload`** — detection inputs come from
the client at init time. No reason to wait for the S3 upload to finish.

### What's Next

- **Frontend**: send metadata fields in `UploadVideoInitRequest` (MediaInfo.js
  already extracts them)
- **Pipeline A**: implement concert detection API integration, then song/artist
  detection
- **Pipeline B**: post-upload ffprobe fallback — simple goroutine from
  `ConfirmUpload`, no job queue needed
- Go Dockerfile, CI/CD, tests
