### PR TITLE
DTO to separate directory, group by functionality

### DIFF
--- a/backend-go/dto/concert_detect_dto.go
+++ b/backend-go/dto/concert_detect_dto.go
@@ -1,6 +1,10 @@
-package models
+package dto
 
-import "time"
+import (
+	"time"
+
+	"github.com/areeeeeeeb/reLive/backend-go/models"
+)
 
 // ConcertDetectRequest holds client-provided metadata used to match against concerts.
 // All fields are optional — results degrade gracefully if some are absent.
@@ -12,8 +16,8 @@ type ConcertDetectRequest struct {
 
 // ConcertMatch pairs a concert candidate with its detection confidence score.
 type ConcertMatch struct {
-	Concert Concert `json:"concert"`
-	Score   float64 `json:"score"`
+	Concert models.Concert `json:"concert"`
+	Score   float64        `json:"score"`
 }
 
 // ConcertDetectResult is returned from POST /concerts/detect.

--- a/backend-go/dto/search_dto.go
+++ b/backend-go/dto/search_dto.go
@@ -1,4 +1,4 @@
-package models
+package dto
 
 const (
 	SearchSourceLocal    = "local"

--- a/backend-go/dto/user_auth_dto.go
+++ b/backend-go/dto/user_auth_dto.go
@@ -1,4 +1,4 @@
-package models
+package dto
 
 // SyncUserRequest for syncing user from Auth0 on login
 type SyncUserRequest struct {
@@ -21,4 +21,3 @@ type UpdateProfileRequest struct {
 	ProfilePicture string `json:"profile_picture"`
 	Bio            string `json:"bio"`
 }
-

--- a/backend-go/dto/video_upload_dto.go
+++ b/backend-go/dto/video_upload_dto.go
@@ -1,4 +1,4 @@
-package models
+package dto
 
 import "time"
 
@@ -43,4 +43,3 @@ type UploadConfirmResponse struct {
 	VideoID int    `json:"videoId"`
 	Status  string `json:"status"`
 }
-

--- a/backend-go/handlers/artist_handler.go
+++ b/backend-go/handlers/artist_handler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/areeeeeeeb/reLive/backend-go/apperr"
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/services"
 	"github.com/gin-gonic/gin"
 )
@@ -19,7 +19,7 @@ func NewArtistHandler(artistService *services.ArtistService) *ArtistHandler {
 	return &ArtistHandler{artistService: artistService}
 }
 
-//	GET /artists/:id
+// GET /artists/:id
 func (h *ArtistHandler) Get(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -43,22 +43,23 @@ func (h *ArtistHandler) Get(c *gin.Context) {
 // Search returns artists matching a query string.
 //
 //	GET /artists/search?q=radiohead&max_results=10&source=mixed
+//
 // default (main) behavior is to search both local and external sources
 // this can be overridden by setting the source query parameter
 func (h *ArtistHandler) Search(c *gin.Context) {
-	var req models.SearchRequest
+	var req dto.SearchRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if req.MaxResults <= 0 {
-		req.MaxResults = models.SearchMaxResultsDefault
+		req.MaxResults = dto.SearchMaxResultsDefault
 	}
-	if req.MaxResults > models.SearchMaxResultsMax {
-		req.MaxResults = models.SearchMaxResultsMax
+	if req.MaxResults > dto.SearchMaxResultsMax {
+		req.MaxResults = dto.SearchMaxResultsMax
 	}
 	if req.Source == "" {
-		req.Source = models.SearchDefaultSource
+		req.Source = dto.SearchDefaultSource
 	}
 
 	artists, err := h.artistService.Search(c.Request.Context(), req.Q, req.MaxResults, req.Source)

--- a/backend-go/handlers/concert_handler.go
+++ b/backend-go/handlers/concert_handler.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/areeeeeeeb/reLive/backend-go/apperr"
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/services"
 	"github.com/gin-gonic/gin"
 )
@@ -97,7 +97,7 @@ func (h *ConcertHandler) ListSongPerformances(c *gin.Context) {
 // POST /v2/api/concerts/detect
 // Stateless: returns top concert candidates for the given GPS coordinates and timestamp.
 func (h *ConcertHandler) Detect(c *gin.Context) {
-	var req models.ConcertDetectRequest
+	var req dto.ConcertDetectRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return

--- a/backend-go/handlers/song_handler.go
+++ b/backend-go/handlers/song_handler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/areeeeeeeb/reLive/backend-go/apperr"
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/services"
 	"github.com/gin-gonic/gin"
 )
@@ -45,22 +45,23 @@ func (h *SongHandler) Get(c *gin.Context) {
 // Search returns songs matching a query string.
 //
 //	GET /songs/search?q=creep&max_results=10&source=mixed
+//
 // default (main) behavior is to search both local and external sources
 // this can be overridden by setting the source query parameter
 func (h *SongHandler) Search(c *gin.Context) {
-	var req models.SearchRequest
+	var req dto.SearchRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if req.MaxResults <= 0 {
-		req.MaxResults = models.SearchMaxResultsDefault
+		req.MaxResults = dto.SearchMaxResultsDefault
 	}
-	if req.MaxResults > models.SearchMaxResultsMax {
-		req.MaxResults = models.SearchMaxResultsMax
+	if req.MaxResults > dto.SearchMaxResultsMax {
+		req.MaxResults = dto.SearchMaxResultsMax
 	}
 	if req.Source == "" {
-		req.Source = models.SearchDefaultSource
+		req.Source = dto.SearchDefaultSource
 	}
 
 	songs, err := h.songService.Search(c.Request.Context(), req.Q, req.MaxResults, req.Source)

--- a/backend-go/handlers/user_handler.go
+++ b/backend-go/handlers/user_handler.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/services"
 	"github.com/gin-gonic/gin"
 )
@@ -15,7 +15,7 @@ func NewUserHandler(userService *services.UserService) *UserHandler {
 }
 
 func (h *UserHandler) Sync(c *gin.Context) {
-	var req models.SyncUserRequest
+	var req dto.SyncUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -31,13 +31,13 @@ func (h *UserHandler) Sync(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	
+
 	c.JSON(200, gin.H{"user": user})
 }
 
 // TestSync bypasses auth for local testing
 func (h *UserHandler) TestSync(c *gin.Context) {
-	var req models.TestSyncRequest
+	var req dto.TestSyncRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return

--- a/backend-go/handlers/video_handler.go
+++ b/backend-go/handlers/video_handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/models"
 	"github.com/areeeeeeeb/reLive/backend-go/services"
 	"github.com/gin-gonic/gin"
@@ -29,7 +30,7 @@ func (h *VideoHandler) Get(c *gin.Context) {
 
 // POST /videos/upload/init
 func (h *VideoHandler) UploadInit(c *gin.Context) {
-	var req models.UploadInitRequest
+	var req dto.UploadInitRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -52,7 +53,7 @@ func (h *VideoHandler) UploadInit(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, models.UploadInitResponse{
+	c.JSON(200, dto.UploadInitResponse{
 		VideoID:  result.VideoID,
 		UploadID: result.UploadID,
 		PartURLs: result.PartURLs,
@@ -62,7 +63,7 @@ func (h *VideoHandler) UploadInit(c *gin.Context) {
 
 // POST /videos/:id/upload/confirm
 func (h *VideoHandler) UploadConfirm(c *gin.Context) {
-	var req models.UploadConfirmRequest
+	var req dto.UploadConfirmRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -85,7 +86,7 @@ func (h *VideoHandler) UploadConfirm(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, models.UploadConfirmResponse{
+	c.JSON(200, dto.UploadConfirmResponse{
 		VideoID: videoID,
 		Status:  models.VideoStatusCompleted,
 	})

--- a/backend-go/services/artist_service.go
+++ b/backend-go/services/artist_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/areeeeeeeb/reLive/backend-go/database"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/models"
 )
 
@@ -27,11 +28,11 @@ func (s *ArtistService) Search(ctx context.Context, query string, maxResults int
 	}
 
 	switch source {
-	case models.SearchSourceLocal:
+	case dto.SearchSourceLocal:
 		return s.store.SearchArtists(ctx, query, maxResults)
-	case models.SearchSourceExternal:
+	case dto.SearchSourceExternal:
 		return nil, fmt.Errorf("external source not implemented for artists")
-	case models.SearchSourceMixed:
+	case dto.SearchSourceMixed:
 		return nil, fmt.Errorf("mixed source not implemented for artists")
 	default:
 		return nil, fmt.Errorf("invalid source: %s", source)

--- a/backend-go/services/detection_service.go
+++ b/backend-go/services/detection_service.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/areeeeeeeb/reLive/backend-go/database"
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 )
 
 // DetectionService contains all detection logic when the client explicitly triggers a detect request
@@ -20,9 +20,9 @@ func NewDetectionService(store *database.Store) *DetectionService {
 // DetectConcert attempts to match the provided metadata to a concert.
 // Stateless — no DB writes. Returns top candidates ordered by confidence score.
 // Returns a non-nil error only for infrastructure failures (e.g. DB query failed).
-func (ds *DetectionService) DetectConcert(ctx context.Context, req models.ConcertDetectRequest) (*models.ConcertDetectResult, error) {
+func (ds *DetectionService) DetectConcert(ctx context.Context, req dto.ConcertDetectRequest) (*dto.ConcertDetectResult, error) {
 	// TODO: implement GPS + timestamp concert matching against concerts table.
 	log.Printf("[detection] detection not yet implemented")
 
-	return &models.ConcertDetectResult{Detected: false, Matches: []models.ConcertMatch{}}, nil
+	return &dto.ConcertDetectResult{Detected: false, Matches: []dto.ConcertMatch{}}, nil
 }

--- a/backend-go/services/search_service.go
+++ b/backend-go/services/search_service.go
@@ -3,7 +3,7 @@ package services
 import (
 	"fmt"
 
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 )
 
 // SearchService is a shared toolkit for search operations.
@@ -19,12 +19,11 @@ func NewSearchService() *SearchService {
 
 // ValidateMaxResults checks that maxResults is within allowed bounds.
 func (s *SearchService) ValidateMaxResults(maxResults int) error {
-	if maxResults <= 0 || maxResults > models.SearchMaxResultsMax {
-		return fmt.Errorf("invalid max_results: %d (must be 1-%d)", maxResults, models.SearchMaxResultsMax)
+	if maxResults <= 0 || maxResults > dto.SearchMaxResultsMax {
+		return fmt.Errorf("invalid max_results: %d (must be 1-%d)", maxResults, dto.SearchMaxResultsMax)
 	}
 	return nil
 }
-
 
 // PAUSED DUE TO MUSICBRAINZ RATE LIMITING CONCERNS
 // FetchMBArtists(ctx, query) ([]MBArtistResult, error)

--- a/backend-go/services/song_service.go
+++ b/backend-go/services/song_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/areeeeeeeb/reLive/backend-go/database"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/models"
 )
 
@@ -27,11 +28,11 @@ func (s *SongService) Search(ctx context.Context, query string, maxResults int, 
 	}
 
 	switch source {
-	case models.SearchSourceLocal:
+	case dto.SearchSourceLocal:
 		return s.store.SearchSongs(ctx, query, maxResults)
-	case models.SearchSourceExternal:
+	case dto.SearchSourceExternal:
 		return nil, fmt.Errorf("external source not implemented for songs")
-	case models.SearchSourceMixed:
+	case dto.SearchSourceMixed:
 		return nil, fmt.Errorf("mixed source not implemented for songs")
 	default:
 		return nil, fmt.Errorf("invalid source: %s", source)

--- a/backend-go/services/upload_service.go
+++ b/backend-go/services/upload_service.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/areeeeeeeb/reLive/backend-go/models"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 const (
-	MinPartSize = 5 * 1024 * 1024  // 5MB minimum for S3
-	MaxParts    = 10000            // S3 limit
+	MinPartSize = 5 * 1024 * 1024 // 5MB minimum for S3
+	MaxParts    = 10000           // S3 limit
 )
 
 // CalculatePartSize returns optimal part size based on file size
@@ -43,6 +43,7 @@ func CalculatePartCount(SizeBytes int64, partSize int64) int {
 	}
 	return int(count)
 }
+
 type UploadService struct {
 	s3Client      *s3.Client
 	presignClient *s3.PresignClient
@@ -83,10 +84,10 @@ func (s *UploadService) GeneratePresignedPartUrls(ctx context.Context, key strin
 	for i := range partCount {
 		partNumber := int32(i + 1)
 		presigned, err := s.presignClient.PresignUploadPart(ctx, &s3.UploadPartInput{
-			Bucket:   aws.String(s.bucket),
-			Key:      aws.String(key),
+			Bucket:     aws.String(s.bucket),
+			Key:        aws.String(key),
 			PartNumber: aws.Int32(partNumber),
-			UploadId: aws.String(uploadID),
+			UploadId:   aws.String(uploadID),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate presigned URL for part %d: %w", partNumber, err)
@@ -110,7 +111,7 @@ func (s *UploadService) AbortMultipartUpload(ctx context.Context, key string, up
 }
 
 // CompleteMultipartUpload finalizes a multipart upload
-func (s *UploadService) CompleteMultipartUpload(ctx context.Context, key string, uploadID string, parts []models.UploadPart) error {
+func (s *UploadService) CompleteMultipartUpload(ctx context.Context, key string, uploadID string, parts []dto.UploadPart) error {
 	// Convert to S3 CompletedPart format
 	completedParts := make([]s3Types.CompletedPart, len(parts))
 	for i, part := range parts {

--- a/backend-go/services/video_service.go
+++ b/backend-go/services/video_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/areeeeeeeb/reLive/backend-go/apperr"
 	"github.com/areeeeeeeb/reLive/backend-go/database"
+	"github.com/areeeeeeeb/reLive/backend-go/dto"
 	"github.com/areeeeeeeb/reLive/backend-go/models"
 	"github.com/google/uuid"
 )
@@ -35,9 +36,8 @@ func NewVideoService(store *database.Store, upload *UploadService) *VideoService
 	}
 }
 
-// InitUpload takes the full UploadInitRequest because all fields are needed together
-// and UploadInitRequest lives in models (not the handler layer), keeping the coupling acceptable.
-func (s *VideoService) InitUpload(ctx context.Context, userID int, req *models.UploadInitRequest) (*InitUploadResult, error) {
+// InitUpload takes the full UploadInitRequest because all fields are needed together.
+func (s *VideoService) InitUpload(ctx context.Context, userID int, req *dto.UploadInitRequest) (*InitUploadResult, error) {
 	if !strings.HasPrefix(req.ContentType, "video/") {
 		return nil, fmt.Errorf("invalid content type: %s, must be a video", req.ContentType)
 	}
@@ -79,7 +79,7 @@ func (s *VideoService) InitUpload(ctx context.Context, userID int, req *models.U
 
 // ConfirmUpload completes a multipart upload and marks the video as completed.
 // Thumbnail extraction is handled asynchronously by JobQueueService.
-func (s *VideoService) ConfirmUpload(ctx context.Context, videoID int, userID int, uploadID string, parts []models.UploadPart) error {
+func (s *VideoService) ConfirmUpload(ctx context.Context, videoID int, userID int, uploadID string, parts []dto.UploadPart) error {
 	video, err := s.store.GetVideoByID(ctx, videoID)
 	if err != nil {
 		return fmt.Errorf("video not found: %w", err)


### PR DESCRIPTION
### What Changed?
- Introduced a dedicated `backend-go/dto` package for transport-layer request/response contracts.
- Moved DTO definitions out of `backend-go/models` into functionality-scoped files:
  - `search_dto.go`
  - `concert_detect_dto.go`
  - `video_upload_dto.go`
  - `user_auth_dto.go`
- Updated handlers/services to import and use `dto.*` types/constants instead of `models.*` DTO types.
- Kept domain entities in `backend-go/models` (Artist, Song, Concert, Video, etc.) and removed DTO files from that package.
- Renamed DTO files with `_dto` suffix for IDE discoverability and consistency.

### Why make this change?
DTOs are API transport contracts, not domain concepts. They only make sense in the context of a specific API workflow (search, concert detection, upload, auth), not as core business models.

Separating them from `models`:
- keeps the domain layer clean and focused on business entities,
- makes API contract changes safer and easier to reason about,
- improves discoverability by grouping DTOs by functionality,
- sets up cleaner versioning/evolution of API contracts later (e.g., `dto/v2`) without polluting domain models.