### PR TITLE
add local development environment setup

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -1,0 +1,137 @@
+# Local Development Setup
+
+Local dev runs PostgreSQL and MinIO (S3-compatible) in Docker. No cloud credentials needed.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [golang-migrate](https://github.com/golang-migrate/migrate) — `go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest`
+- [Go 1.25+](https://go.dev/dl/)
+
+---
+
+## First-time setup
+
+```bash
+cd backend-go
+
+# 1. Copy the local env template
+cp .env.local.example .env
+
+# 2. Start Docker services and run all migrations
+make local-setup
+
+# 3. Start the backend
+make dev
+```
+
+The backend will be running at **http://localhost:8081**.
+
+---
+
+## Daily workflow
+
+```bash
+# Start containers (if not already running)
+make local-up
+
+# Start backend
+make dev
+
+# Stop containers when done
+make local-down
+```
+
+---
+
+## Services
+
+| Service | URL | Credentials |
+|---|---|---|
+| Backend API | http://localhost:8081 | — |
+| MinIO S3 API | http://localhost:9000 | — |
+| MinIO Console | http://localhost:9001 | `minioadmin` / `minioadmin123` |
+| PostgreSQL | `localhost:5434` | `relive` / `relive` |
+
+---
+
+## Database
+
+### Migrations
+
+```bash
+make migrate-up       # apply all pending migrations
+make migrate-down     # roll back one migration
+make migrate-status   # show current migration version
+make migrate-create   # scaffold a new migration file
+```
+
+### Connect with pgAdmin
+
+Register a new server with these settings:
+
+| Field | Value |
+|---|---|
+| Host | `localhost` |
+| Port | `5434` |
+| Database | `relive` |
+| Username | `relive` |
+| Password | `relive` |
+| SSL | disabled |
+
+### Connect via psql (no install needed)
+
+```bash
+docker exec -it backend-go-postgres-1 psql -U relive -d relive
+```
+
+---
+
+## S3 / MinIO
+
+Uploaded files are stored in the `relive-concert-media` bucket.
+
+Browse files at **http://localhost:9001** — login with `minioadmin` / `minioadmin123`.
+
+The bucket is created automatically on `make local-up`.
+
+---
+
+## Auth
+
+Auth0 is bypassed in local dev. Every request is authenticated as the user defined by `DEV_AUTH0_ID` in your `.env`.
+
+```env
+DEV_BYPASS_AUTH=true
+DEV_AUTH0_ID=local|dev-user
+```
+
+Change `DEV_AUTH0_ID` to match a specific `auth0_id` in your local `users` table if you need to test as a specific user.
+
+---
+
+## Reset everything
+
+```bash
+make local-reset      # stops containers and wipes all data volumes
+make local-setup      # fresh start: recreates containers + remigrates
+```
+
+---
+
+## Troubleshooting
+
+**`password authentication failed for user "relive"`**
+The Postgres volume was initialized with different credentials. Run:
+```bash
+make local-reset && make local-setup
+```
+
+**Port conflict on `5434` or `9000`/`9001`**
+Another process is using that port. Change the host-side port in `docker-compose.local.yml` and update `DATABASE_URL` / `DO_SPACES_ENDPOINT` in your `.env` to match.
+
+**`make dev` fails — database unreachable**
+Containers may not be running. Check with:
+```bash
+docker compose -f docker-compose.local.yml ps
+```

--- a/backend-go/.env.local.example
+++ b/backend-go/.env.local.example
@@ -1,0 +1,38 @@
+# Local development environment
+# Copy this file to .env:  cp .env.local.example .env
+# Then run:               make local-setup
+
+PORT=8081
+ENVIRONMENT=development
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Local PostgreSQL started by docker-compose.local.yml
+DATABASE_URL=postgresql://relive:relive@localhost:5434/relive?sslmode=disable
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+# Bypass Auth0 entirely in local dev.
+# Set DEV_AUTH0_ID to any stable string — it becomes your "logged-in" user.
+DEV_BYPASS_AUTH=true
+DEV_AUTH0_ID=local|dev-user
+
+# Leave blank when DEV_BYPASS_AUTH=true
+AUTH0_DOMAIN=
+AUTH0_AUDIENCE=
+
+# ── Storage (MinIO) ───────────────────────────────────────────────────────────
+# Local MinIO started by docker-compose.local.yml
+# Console UI: http://localhost:9001  (login: minioadmin / minioadmin123)
+DO_SPACES_ENDPOINT=http://localhost:9000
+DO_SPACES_BUCKET=relive-concert-media
+DO_SPACES_REGION=us-east-1
+DO_SPACES_KEY=minioadmin
+DO_SPACES_SECRET=minioadmin123
+# No CDN locally — URLs point directly at MinIO
+DO_SPACES_CDN_URL=http://localhost:9000/relive-concert-media
+
+# ── Worker pool ───────────────────────────────────────────────────────────────
+POOL_CONCURRENCY=5
+POOL_QUEUE_SIZE=50
+SCHEDULER_INTERVAL_SECS=30
+STUCK_THRESHOLD_MINS=10
+RESET_INTERVAL_MINS=5

--- a/backend-go/Makefile
+++ b/backend-go/Makefile
@@ -2,9 +2,31 @@
 include .env
 export
 
-.PHONY: dev migrate-up migrate-down migrate-create migrate-status test
+.PHONY: dev migrate-up migrate-down migrate-create migrate-status test \
+        local-up local-down local-reset local-setup
 
-# Development server
+# ── Local infrastructure ──────────────────────────────────────────────────────
+
+# Start local PostgreSQL + MinIO (detached)
+local-up:
+	docker compose -f docker-compose.local.yml up -d
+
+# Stop local services (keeps volumes)
+local-down:
+	docker compose -f docker-compose.local.yml down
+
+# Wipe volumes and stop — full clean slate
+local-reset:
+	docker compose -f docker-compose.local.yml down -v
+
+# First-time setup: start services, wait for healthy, then migrate
+local-setup: local-up
+	@echo "Waiting for services to be healthy..."
+	@docker compose -f docker-compose.local.yml wait postgres minio minio-init 2>/dev/null || sleep 8
+	@$(MAKE) migrate-up
+
+# ── Development server ────────────────────────────────────────────────────────
+
 dev:
 	go run main.go
 
@@ -45,6 +67,14 @@ clean:
 # Help
 help:
 	@echo "Available commands:"
+	@echo ""
+	@echo "  Local infrastructure (Docker):"
+	@echo "  make local-setup      - First-time: start services + migrate"
+	@echo "  make local-up         - Start PostgreSQL + MinIO"
+	@echo "  make local-down       - Stop services (keep data)"
+	@echo "  make local-reset      - Stop services and wipe all data"
+	@echo ""
+	@echo "  Development:"
 	@echo "  make dev              - Run development server"
 	@echo "  make migrate-up       - Run pending migrations"
 	@echo "  make migrate-down     - Rollback last migration"

--- a/backend-go/docker-compose.local.yml
+++ b/backend-go/docker-compose.local.yml
@@ -1,0 +1,52 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: relive
+      POSTGRES_PASSWORD: relive
+      POSTGRES_DB: relive
+    ports:
+      - "5434:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U relive"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console (http://localhost:9001)
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # One-shot container: creates the bucket then exits
+  minio-init:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 minioadmin minioadmin123 &&
+        mc mb --ignore-existing local/relive-concert-media &&
+        echo 'Bucket relive-concert-media is ready.'
+      "
+    restart: on-failure
+
+volumes:
+  postgres_data:
+  minio_data:


### PR DESCRIPTION
# Local Development Setup

Local dev runs PostgreSQL and MinIO (S3-compatible) in Docker. No cloud credentials needed.

## Prerequisites

- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
- [golang-migrate](https://github.com/golang-migrate/migrate) — `go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest`
- [Go 1.25+](https://go.dev/dl/)

---

## First-time setup

```bash
cd backend-go

# 1. Copy the local env template
cp .env.local.example .env

# 2. Start Docker services and run all migrations
make local-setup

# 3. Start the backend
make dev
```

The backend will be running at **http://localhost:8081**.

---

## Daily workflow

```bash
# Start containers (if not already running)
make local-up

# Start backend
make dev

# Stop containers when done
make local-down
```

---

## Services

| Service | URL | Credentials |
|---|---|---|
| Backend API | http://localhost:8081 | — |
| MinIO S3 API | http://localhost:9000 | — |
| MinIO Console | http://localhost:9001 | `minioadmin` / `minioadmin123` |
| PostgreSQL | `localhost:5434` | `relive` / `relive` |

---

## Database

### Migrations

```bash
make migrate-up       # apply all pending migrations
make migrate-down     # roll back one migration
make migrate-status   # show current migration version
make migrate-create   # scaffold a new migration file
```

### Connect with pgAdmin

Register a new server with these settings:

| Field | Value |
|---|---|
| Host | `localhost` |
| Port | `5434` |
| Database | `relive` |
| Username | `relive` |
| Password | `relive` |
| SSL | disabled |

### Connect via psql (no install needed)

```bash
docker exec -it backend-go-postgres-1 psql -U relive -d relive
```

---

## S3 / MinIO

Uploaded files are stored in the `relive-concert-media` bucket.

Browse files at **http://localhost:9001** — login with `minioadmin` / `minioadmin123`.

The bucket is created automatically on `make local-up`.

---

## Auth

Auth0 is bypassed in local dev. Every request is authenticated as the user defined by `DEV_AUTH0_ID` in your `.env`.

```env
DEV_BYPASS_AUTH=true
DEV_AUTH0_ID=local|dev-user
```

Change `DEV_AUTH0_ID` to match a specific `auth0_id` in your local `users` table if you need to test as a specific user.

---

## Reset everything

```bash
make local-reset      # stops containers and wipes all data volumes
make local-setup      # fresh start: recreates containers + remigrates
```

---

## Troubleshooting

**`password authentication failed for user "relive"`**
The Postgres volume was initialized with different credentials. Run:
```bash
make local-reset && make local-setup
```

**Port conflict on `5434` or `9000`/`9001`**
Another process is using that port. Change the host-side port in `docker-compose.local.yml` and update `DATABASE_URL` / `DO_SPACES_ENDPOINT` in your `.env` to match.

**`make dev` fails — database unreachable**
Containers may not be running. Check with:
```bash
docker compose -f docker-compose.local.yml ps
```